### PR TITLE
add manpages and less, mirroring swc-unix-shell PR1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,17 @@ FROM jupyter/scipy-notebook@sha256:41911b6f333f464a05b503636e6fb03005f2c11e72c27
 
 MAINTAINER David Naughton <naughton@umn.edu>
 
+USER root
+# Remove the manpage blacklist, install man, install manpages
+RUN rm /etc/dpkg/dpkg.cfg.d/excludes && \
+    apt update -y && \
+    apt install -y less && \
+    dpkg -l | grep ^ii | cut -d' ' -f3 | xargs apt install -yq --no-install-recommends --reinstall man && \
+    apt clean && \
+    mv /usr/bin/man.REAL /usr/bin/man && \
+    rm -rf /var/lib/apt/lists/*
+
+USER $NB_UID
+
 RUN mkdir "/home/${NB_USER}/Desktop" && \
     chmod -R g+rw "/home/${NB_USER}/Desktop"


### PR DESCRIPTION
Apply same [changes as used on Unix shell image](https://github.com/umn-dash/swc-unix-shell/pull/1) to restore `manpages`. The curriculum includes and example that fails if `man` and content are not available.